### PR TITLE
fix a security issue: handle the back button on PinLock page 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 ### Description
 Please describe your pull request.
 
-💔Thank you!
+❤️Thank you!

--- a/src/pages/PinLock.vue
+++ b/src/pages/PinLock.vue
@@ -47,6 +47,13 @@ export default {
       this.isios = true
     }
   },
+  mounted() {
+    document.removeEventListener("backbutton", this.onBackKeyDown, false); 
+    document.addEventListener("backbutton", this.onBackKeyDown, false); 
+  },
+  beforeDestroy() {
+    document.removeEventListener("backbutton", this.onBackKeyDown, false); 
+  },
   methods: {
     ...mapActions([ ]),
     
@@ -59,6 +66,10 @@ export default {
         this.$toasted.error(this.$t('Error.PinCodeIsWrong'))
       }
     },
+    onBackKeyDown() {
+      // Todo: 这里等待补充更多的逻辑，比如双击退出之类的。
+      this.exitapp()
+    } ,
     exitapp(){
       console.log(navigator)
       console.log(navigator.app)


### PR DESCRIPTION
### Description
Please describe your pull request.
处理 PinLock 页面的返回按钮，没有处理的话在 Android 设备上这个页面形同虚设，只要按一下返回按钮就可以跳过了。本来想参考一下 Main.vue 里面的双击退出的，但是目前的双击返回好像有 bug，等之后再处理吧。
💔Thank you! <-emmm 还有这个心碎是什么
